### PR TITLE
Add type definitions for isIPv6

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,3 @@
+declare function isIPv6(text: string): boolean;
+
+export = isIPv6;

--- a/package.json
+++ b/package.json
@@ -71,5 +71,6 @@
   ],
   "preferGlobal": false,
   "private": false,
+  "types": "./index.d.ts",
   "publishConfig": {}
 }


### PR DESCRIPTION
Hello,

This PR adds [type definitions](http://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html) (`index.d.ts` + `types`) so when using `is-ipv6-node` from a TypeScript project the compiler would properly see the dependency and function argument/return value.